### PR TITLE
saving blue-tape practice test

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -260,6 +260,14 @@ const difference = (first, second, idx = 0, out = []) => {
   return difference(first, second, idx, out);
 };
 
+//practice blue-tape test
+const delay = () => {
+  const promise = new Promise((resolve, reject) => setTimeout(function (){
+    resolve('Success!');
+  }, 250));
+  return promise;
+};
+
 module.exports = {
   pluck,
   some,
@@ -281,4 +289,5 @@ module.exports = {
   slice,
   uniq,
   range,
+  delay
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "lint": "eslint .",
     "pretest": "npm run -s lint",
-    "test": "cross-env NODE_PATH='source' node test/index.js | node_modules/.bin/tap-dot",
+    "test": "cross-env NODE_PATH='source' node test/index.js | tap-dot",
     "watch": "watch 'clear && npm run -s test' lib"
   },
   "repository": {
@@ -36,7 +36,7 @@
     "watch": "0.18.0"
   },
   "dependencies": {
-    "tap-dot": "^1.0.5",
-    "tape": "^4.6.3"
+    "blue-tape": "1.0.0",
+    "tap-dot": "^1.0.5"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-const test = require('tape');
+const test = require('blue-tape');
 const {
   some,
   every,
@@ -20,6 +20,7 @@ const {
   slice,
   uniq,
   range,
+  delay
 } = require('../lib/index.js');
 
 test('should test compose', (assert) => {
@@ -243,4 +244,10 @@ test('should create a range', (assert) => {
 
   assert.same(actual, expected, msg);
   assert.end();
+});
+//practice blue tape test
+test('simple delay', (assert) => {
+  return delay().then((value) => {
+    assert.same(value, 'Success!');
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -600,6 +600,12 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+blue-tape@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/blue-tape/-/blue-tape-1.0.0.tgz#7581d04c07395c95c426b2ed6d1edb454a76b92b"
+  dependencies:
+    tape ">=2.0.0 <5.0.0"
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -2337,7 +2343,7 @@ tap-out@^1.3.2:
     split "^1.0.0"
     trim "0.0.1"
 
-tape@^4.6.3:
+"tape@>=2.0.0 <5.0.0":
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/tape/-/tape-4.6.3.tgz#637e77581e9ab2ce17577e9bd4ce4f575806d8b6"
   dependencies:


### PR DESCRIPTION
added blue-tape to the library to see how it worked with promises and to add the layer on the actual library.  replaced the package.json files tape dependency with the blue-tape dependency.